### PR TITLE
Fix Google Sign In

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@
 Changelog
 =========
 
+.. _v_0_4_2:
+
+0.4.2 (2023-06-07)
+------------------
+
+* Fixed the missing Sign In with Google button in the `auth/pages/login.html`` template (:issue:`38`)
+* Fixed an incorrect assign of the Google account name to `user.email`` when creating the account with Google (:issue:`38`)
+
 .. _v_0_4_1:
 
 0.4.1 (2023-06-06)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = 'Django Rocket'
 copyright = '2023, Ernesto F. González'
 author = 'Ernesto F. González'
-release = '0.4.1'
+release = '0.4.2'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.project_slug }}/auth/templates/auth/pages/login.html
+++ b/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.project_slug }}/auth/templates/auth/pages/login.html
@@ -9,11 +9,9 @@
 {% block body %}
     <div class="2xl:container mx-auto px-4 md:px-16 py-5 md:py-10">
         <main class="mx-auto max-w-md rounded border-2 border-[#FFC894] bg-[#FFE2C7] py-10 px-10">
-            <h2 class="mb-10 tracking-tighter text-center text-3xl font-bold text-gray-900">
-                Welcome back
-        </h2>
+            <h2 class="mb-10 tracking-tighter text-center text-3xl font-bold text-gray-900">Welcome back</h2>
 
-        <div id="g_id_onload"
+            <div id="g_id_onload"
                 data-client_id="{{ google_oauth_client_id }}"
                 data-context="signin"
                 data-ux_mode="redirect"
@@ -38,7 +36,7 @@
             </div>
 
             <h2 class="mb-2 text-center text-lg font-bold text-gray-900">Sign in with your email address</h2>
-        <form action="{% url '{%- endraw -%}{{ cookiecutter.project_slug }}{%- raw -%}-auth:login' %}"
+            <form action="{% url '{%- endraw -%}{{ cookiecutter.project_slug }}{%- raw -%}-auth:login' %}"
               method="post"
               class="grid grid-cols-1 gap-y-3">
             {% csrf_token %}
@@ -57,5 +55,6 @@
         </div>
     </main>
 </div>
+<script src="https://accounts.google.com/gsi/client" async defer></script>
 {% endblock %}
 {% endraw %}

--- a/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.project_slug }}/auth/views.py
+++ b/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.project_slug }}/auth/views.py
@@ -163,7 +163,7 @@ def signin_with_google_view(request):
     )
 
     if created:
-        user.email = idinfo["name"]
+        user.name = idinfo["name"]
         user.set_unusable_password()
         create_subscription_for_user(user, settings.SUBSCRIPTION_TRIAL_PERIOD_DAYS)
     


### PR DESCRIPTION
This PR:
- Fixes the missing `Sign in with Google` button in the `auth/pages/login.html` template (issue #38)
- Fixes an incorrect assign of the Google account name to `user.email` when creating the account with Google (issue #38)