### PR TITLE
Fix docs for `cookiecutter` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ pip install cookiecutter==2.1.1 django==5.0.6
 To create a new Django Rocket project, simply run the following command in your terminal:
 
 ```bash
-$ cookiecutter gh:ErnestoFGonzalez/djangorocket --directory="templates/base"
+$ cookiecutter gh:ErnestoFGonzalez/djangorocket --directory="templates/projects/base"
 ```
 
 or using `djangorocket` as a CLI tool

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ To build your project with cookiecutter
 
 .. code-block:: sh 
 
-   cookiecutter gh:ErnestoFGonzalez/djangorocket --directory="templates/base"
+   cookiecutter gh:ErnestoFGonzalez/djangorocket --directory="templates/projects/base"
 
 You'll be prompted to enter some information
 


### PR DESCRIPTION
This PR:
- Updates the docs to use `--directory="templates/projects/base"` for usage with `cookiecutter` (#52)